### PR TITLE
Add Status Code Checking

### DIFF
--- a/CVE-2021-21985.nse
+++ b/CVE-2021-21985.nse
@@ -90,14 +90,14 @@ validation in the Virtual SAN Health Check plug-in which is enabled by default i
 
     if response.status and response.body then 
 
-      if response.status == 200 and string.find(response.body, VULNERABLE1) ~= nil then  
+        if response.status == 200 and string.find(response.body, VULNERABLE1) ~= nil then  
 
           stdnse.debug2("vCenter returned 200, with json data ")
           vuln.state = vulns.STATE.EXPLOIT
 
         end 
 
-        if response.body and string.find(response.body, VULNERABLE2) ~=nil then 
+        if response.status == 200 and response.body and string.find(response.body, VULNERABLE2) ~=nil then 
           stdnse.debug2("vCenter returned 200, with json data errors")
           vuln.state = vulns.STATE.LIKELY_VULN
         end 
@@ -105,17 +105,17 @@ validation in the Virtual SAN Health Check plug-in which is enabled by default i
         -- Patch add authentication to the Virtual SAN Health Check plugin’s /rest/* endpoints
         -- Source: https://attackerkb.com/topics/X85GKjaVER/cve-2021-21985?referrer=home#rapid7-analysis
 
-        if response.body and string.find(response.body, PATCHED) ~=nil then 
+        if response.status == 401 and response.body and string.find(response.body, PATCHED) ~=nil then 
           stdnse.debug2("vCenter returned 401, Unauthorized")
           vuln.state = vulns.STATE.NOT_VULN
         end 
 
-        if response.body and string.find(response.body, UNAVAILABLE1) ~=nil then 
+        if response.status == 503 and response.body and string.find(response.body, UNAVAILABLE1) ~=nil then 
           stdnse.debug2("vCenter returned 503, Service Unavailable")
           vuln.state = vulns.STATE.NOT_VULN
         end 
 
-        if response.body and string.find(response.body, UNAVAILABLE2) ~=nil then 
+        if response.status == 404 and response.body and string.find(response.body, UNAVAILABLE2) ~=nil then 
           stdnse.debug2("vCenter returned 404, The request resource is not available")
           vuln.state = vulns.STATE.NOT_VULN
         end 


### PR DESCRIPTION
The Script doesn't check status codes, instead depending on vCenter's normal behavior. This causes the script to pick up false positives on non-vCenter web servers